### PR TITLE
chore: add composition_paths and compose_with metadata

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -94,6 +94,13 @@ events:
       delivery: at_least_once
       idempotency:
         key_fields: [gap_id, issue_url]
+composition_paths:
+  reads:
+    - "grimoires/laboratory/"
+  writes:
+    - "grimoires/hardening/"
+compose_with:
+  - observer
 pack_dependencies:
   - slug: observer
 identity:


### PR DESCRIPTION
## Summary
- Adds `composition_paths.reads: [grimoires/laboratory/]` — hardening reads observer signals for incident context
- Adds `composition_paths.writes: [grimoires/hardening/]` — hardening writes PMRs, blast radius maps, and hardening actions
- Adds `compose_with: [observer]` — formalizes the existing observer dependency already expressed via `pack_dependencies` and event consumption

## Why
Part of the ecosystem-wide composition metadata fan-out. These fields enable network-level routing and automated composition validation.

## Test plan
- [ ] `yq eval '.' construct.yaml` parses without error
- [ ] Fields are additive only — no existing fields modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)