### PR TITLE
feat: add capability metadata for runtime routing

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -109,6 +109,16 @@ compose_with:
   - observer
 pack_dependencies:
   - slug: observer
+capabilities:
+  model_tier: opus
+  danger_level: critical
+  effort_hint: large
+  downgrade_allowed: false
+  execution_hint: sequential
+  requires:
+    tool_calling: true
+    thinking_traces: true
+    vision: false
 identity:
   persona: identity/persona.yaml
   expertise: identity/expertise.yaml


### PR DESCRIPTION
## Summary
- Add capabilities stanza for runtime model routing

## Changes
- `construct.yaml`: capabilities metadata added (model_tier: opus, danger_level: critical, effort_hint: large)

## Context
Network audit (2026-03-17) found 21/22 constructs had no capability metadata.
Only vocabulary-bank had a partial stanza. This blocks runtime routing.